### PR TITLE
feat(SO-58): wire ProjectLightbox to hero card clicks on index page

### DIFF
--- a/src/components/projects/ProjectLightbox.astro
+++ b/src/components/projects/ProjectLightbox.astro
@@ -1,0 +1,483 @@
+---
+/**
+ * ProjectLightbox.astro — Dialog shell for the project detail lightbox.
+ *
+ * Mirrors the PersonLightbox pattern (if/when it exists).
+ * Content is populated dynamically by project-lightbox.ts after the dialog opens.
+ *
+ * CSS namespace: plb2-*  (NOT plb-* which belongs to PersonLightbox)
+ *
+ * Usage:
+ *   1. Include <ProjectLightbox /> once in the page.
+ *   2. In a client-side <script>, call:
+ *        import { initProjectLightbox, openProjectLightbox } from '../lib/projects/project-lightbox';
+ *        initProjectLightbox();
+ *        card.addEventListener('click', () => openProjectLightbox(slug, base));
+ */
+---
+
+<dialog
+  id="project-modal"
+  class="plb2-dialog"
+  aria-modal="true"
+  aria-labelledby="project-modal-title"
+>
+  <div class="plb2-dialog-box" role="document">
+    <div class="plb2-dialog-toolbar">
+      <button
+        id="project-modal-close"
+        class="plb2-close-btn"
+        aria-label="Close project details"
+        type="button"
+      >✕</button>
+    </div>
+    <div id="project-modal-content" class="plb2-dialog-content">
+      <!-- Populated by project-lightbox.ts after dialog opens -->
+    </div>
+  </div>
+</dialog>
+
+<style>
+/* ─── plb2-* namespace: Project Lightbox styles ─────────────────────────── */
+/* These rules are SCOPED to this component. They do NOT conflict with        */
+/* plb-* rules in PersonLightbox because the class names are distinct.        */
+
+/* Backdrop / overlay */
+.plb2-dialog {
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  padding: 0;
+  border: none;
+  background: transparent;
+  max-width: 100vw;
+  max-height: 100dvh;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.plb2-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+}
+
+/* Not-open state: hide without display:none so dialog API still works */
+.plb2-dialog:not([open]) {
+  display: none;
+}
+
+/* Inner content box */
+.plb2-dialog-box {
+  position: relative;
+  background: var(--color-bg-default, #ffffff);
+  border: 1px solid var(--color-border-default, #d0d7de);
+  border-radius: 12px;
+  width: min(720px, 94vw);
+  max-height: min(88dvh, 800px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.24);
+}
+
+/* Toolbar row (close button) */
+.plb2-dialog-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-default, #d0d7de);
+  background: var(--color-bg-secondary, #f6f8fa);
+  flex-shrink: 0;
+}
+
+.plb2-close-btn {
+  background: none;
+  border: 1px solid var(--color-border-default, #d0d7de);
+  border-radius: 6px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #57606a);
+  cursor: pointer;
+  line-height: 1;
+  transition: background 0.15s, border-color 0.15s;
+}
+.plb2-close-btn:hover {
+  background: var(--color-bg-tertiary, #eaeef2);
+  border-color: var(--color-text-muted, #656d76);
+  color: var(--color-text-primary, #24292f);
+}
+.plb2-close-btn:focus-visible {
+  outline: 2px solid var(--color-accent-emphasis, #0969da);
+  outline-offset: 2px;
+}
+
+/* Scrollable content area */
+.plb2-dialog-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ─── Header ─────────────────────────────────────────────────────────────── */
+:global(.plb2-header) {
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-start;
+}
+
+:global(.plb2-logo-wrap) {
+  flex-shrink: 0;
+}
+
+:global(.plb2-logo) {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  border-radius: 8px;
+}
+
+:global(.plb2-logo-placeholder) {
+  width: 80px;
+  height: 80px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--plb2-color, #888) 15%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--plb2-color, #888);
+}
+
+:global(.plb2-header-info) {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+:global(.plb2-title-row) {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+:global(.plb2-title) {
+  margin: 0;
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #24292f);
+  line-height: 1.2;
+}
+
+:global(.plb2-maturity-badge) {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--plb2-color, #888) 18%, transparent);
+  color: var(--plb2-color, #888);
+  border: 1px solid color-mix(in srgb, var(--plb2-color, #888) 30%, transparent);
+}
+
+:global(.plb2-meta-row) {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+:global(.plb2-category) {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #57606a);
+}
+
+:global(.plb2-badge-accepted) {
+  font-size: 0.7rem;
+  padding: 0.125rem 0.4rem;
+  border-radius: 3px;
+  background: var(--color-bg-tertiary, #eaeef2);
+  color: var(--color-text-muted, #656d76);
+  border: 1px solid var(--color-border-default, #d0d7de);
+}
+
+:global(.plb2-description) {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #57606a);
+  line-height: 1.5;
+}
+
+/* ─── Stats row ──────────────────────────────────────────────────────────── */
+:global(.plb2-stats-row) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  background: var(--color-bg-secondary, #f6f8fa);
+  border: 1px solid var(--color-border-default, #d0d7de);
+  border-radius: 8px;
+}
+
+:global(.plb2-stat) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.125rem;
+  min-width: 64px;
+}
+
+:global(.plb2-stat-icon) {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+:global(.plb2-stat-val) {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #24292f);
+  white-space: nowrap;
+}
+
+:global(.plb2-stat-label) {
+  font-size: 0.6875rem;
+  color: var(--color-text-muted, #656d76);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+/* ─── Health bar ─────────────────────────────────────────────────────────── */
+:global(.plb2-health-bar) {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+  padding: 0.5rem 0.875rem;
+  background: color-mix(in srgb, #00a86b 8%, transparent);
+  border: 1px solid color-mix(in srgb, #00a86b 25%, transparent);
+  border-radius: 6px;
+}
+
+:global(.plb2-health-title) {
+  font-weight: 600;
+  color: var(--color-text-primary, #24292f);
+}
+
+:global(.plb2-health-item) {
+  display: flex;
+  gap: 0.25rem;
+  color: var(--color-text-secondary, #57606a);
+}
+
+:global(.plb2-health-label) {
+  font-weight: 500;
+  color: var(--color-text-primary, #24292f);
+}
+
+:global(.plb2-health-link) {
+  color: var(--color-accent-emphasis, #0969da);
+  text-decoration: none;
+}
+:global(.plb2-health-link:hover) {
+  text-decoration: underline;
+}
+
+/* ─── Security links ─────────────────────────────────────────────────────── */
+:global(.plb2-security-links),
+:global(.plb2-contributors),
+:global(.plb2-endusers),
+:global(.plb2-topics),
+:global(.plb2-external-links) {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+:global(.plb2-section-label) {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted, #656d76);
+}
+
+:global(.plb2-link-chips),
+:global(.plb2-ext-link-row) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+:global(.plb2-security-link),
+:global(.plb2-ext-link) {
+  font-size: 0.8125rem;
+  color: var(--color-accent-emphasis, #0969da);
+  text-decoration: none;
+  padding: 0.25rem 0.625rem;
+  border: 1px solid var(--color-border-default, #d0d7de);
+  border-radius: 4px;
+  transition: background 0.12s, border-color 0.12s;
+}
+:global(.plb2-security-link:hover),
+:global(.plb2-ext-link:hover) {
+  background: var(--color-bg-secondary, #f6f8fa);
+  border-color: var(--color-accent-emphasis, #0969da);
+  text-decoration: none;
+}
+
+/* ─── Contributor minicards ──────────────────────────────────────────────── */
+:global(.plb2-minicards) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+:global(.plb2-minicard) {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
+  background: var(--color-bg-secondary, #f6f8fa);
+  border: 1px solid var(--color-border-default, #d0d7de);
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.12s, background 0.12s;
+  min-width: 0;
+}
+:global(.plb2-minicard:hover) {
+  border-color: var(--color-accent-emphasis, #0969da);
+  background: var(--color-bg-tertiary, #eaeef2);
+}
+
+:global(.plb2-minicard-avatar) {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+:global(.plb2-minicard-avatar-placeholder) {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--color-bg-tertiary, #eaeef2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #57606a);
+}
+
+:global(.plb2-minicard-info) {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+:global(.plb2-minicard-name) {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #24292f);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 120px;
+}
+
+:global(.plb2-minicard-handle) {
+  font-size: 0.6875rem;
+  color: var(--color-text-muted, #656d76);
+}
+
+:global(.plb2-no-maintainers) {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted, #656d76);
+  margin: 0;
+}
+
+/* ─── End users ──────────────────────────────────────────────────────────── */
+:global(.plb2-endusers-link) {
+  font-size: 0.8125rem;
+  color: var(--color-accent-emphasis, #0969da);
+  text-decoration: none;
+}
+:global(.plb2-endusers-link:hover) {
+  text-decoration: underline;
+}
+
+/* ─── Topics ─────────────────────────────────────────────────────────────── */
+:global(.plb2-topic-chips) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+:global(.plb2-topic-chip) {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  background: var(--color-bg-tertiary, #eaeef2);
+  color: var(--color-text-secondary, #57606a);
+  border-radius: 12px;
+  border: 1px solid var(--color-border-default, #d0d7de);
+}
+
+/* ─── State messages ─────────────────────────────────────────────────────── */
+:global(.plb2-loading),
+:global(.plb2-error) {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-secondary, #57606a);
+  font-size: 0.875rem;
+}
+
+:global(.plb2-error) {
+  color: #cf222e;
+}
+
+/* ─── Dark mode overrides ────────────────────────────────────────────────── */
+[data-theme="dark"] :global(.plb2-dialog-box) {
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.6);
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  :global(.plb2-header) {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  :global(.plb2-title-row) {
+    justify-content: center;
+  }
+
+  :global(.plb2-meta-row) {
+    justify-content: center;
+  }
+
+  :global(.plb2-stats-row) {
+    justify-content: center;
+  }
+
+  .plb2-dialog-content {
+    padding: 1rem;
+  }
+}
+</style>

--- a/src/lib/projects/project-health.ts
+++ b/src/lib/projects/project-health.ts
@@ -1,0 +1,142 @@
+/**
+ * project-health.ts
+ *
+ * Pure TypeScript DORA-style composite health score (0–100) derived from
+ * existing SafeProject fields.  No external I/O — suitable for use in
+ * both the browser bundle and Vitest unit tests.
+ *
+ * Score weights
+ * ─────────────
+ *  Activity   30 %  – days since lastCommitDate   (lower = better)
+ *  Velocity   25 %  – days since lastReleaseDate  (lower = better)
+ *  Community  25 %  – log(contributors)/log(1000) (higher = better)
+ *  Security   20 %  – +50 if audited, +50 if cloMonitorName present
+ *
+ * Grade thresholds
+ * ────────────────
+ *  A  ≥ 80
+ *  B  ≥ 60
+ *  C  ≥ 40
+ *  D  < 40
+ */
+
+import type { SafeProject } from './project-renderer';
+
+export type HealthGrade = 'A' | 'B' | 'C' | 'D';
+
+export interface ProjectHealth {
+  /** Composite score 0–100 (integer) */
+  score: number;
+  /** Letter grade derived from composite score */
+  grade: HealthGrade;
+  /** Breakdown: individual dimension scores (0–100 each) */
+  breakdown: {
+    activity: number;   // 0–100
+    velocity: number;   // 0–100
+    community: number;  // 0–100
+    security: number;   // 0–100
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dimension helpers — all return a value in [0, 100]
+// ---------------------------------------------------------------------------
+
+/**
+ * Activity score: 100 pts if committed today, decays to 0 at 365 days.
+ * Missing lastCommitDate → 0.
+ */
+export function activityScore(lastCommitDate: string | undefined, now = new Date()): number {
+  if (!lastCommitDate) return 0;
+  const d = new Date(lastCommitDate);
+  if (isNaN(d.getTime())) return 0;
+  const days = Math.max(0, (now.getTime() - d.getTime()) / 86_400_000);
+  return Math.round(Math.max(0, 100 - (days / 365) * 100));
+}
+
+/**
+ * Velocity score: 100 pts if released today, decays to 0 at 365 days.
+ * Missing lastReleaseDate → 0.
+ */
+export function velocityScore(lastReleaseDate: string | undefined, now = new Date()): number {
+  if (!lastReleaseDate) return 0;
+  const d = new Date(lastReleaseDate);
+  if (isNaN(d.getTime())) return 0;
+  const days = Math.max(0, (now.getTime() - d.getTime()) / 86_400_000);
+  return Math.round(Math.max(0, 100 - (days / 365) * 100));
+}
+
+/**
+ * Community score: log(contributors) / log(1000) scaled to 0–100.
+ * A project with 1000+ contributors scores 100.
+ * Missing or zero contributors → 0.
+ */
+export function communityScore(contributors: number | undefined): number {
+  if (!contributors || contributors < 1) return 0;
+  const score = (Math.log(contributors) / Math.log(1000)) * 100;
+  return Math.round(Math.min(100, Math.max(0, score)));
+}
+
+/**
+ * Security score: +50 if audited (lastAuditDate present), +50 if cloMonitorName present.
+ */
+export function securityScore(
+  lastAuditDate: string | undefined,
+  cloMonitorName: string | undefined,
+): number {
+  let score = 0;
+  if (lastAuditDate && lastAuditDate.trim() !== '') score += 50;
+  if (cloMonitorName && cloMonitorName.trim() !== '') score += 50;
+  return score;
+}
+
+// ---------------------------------------------------------------------------
+// Grade assignment
+// ---------------------------------------------------------------------------
+
+export function scoreToGrade(score: number): HealthGrade {
+  if (score >= 80) return 'A';
+  if (score >= 60) return 'B';
+  if (score >= 40) return 'C';
+  return 'D';
+}
+
+// ---------------------------------------------------------------------------
+// Composite score
+// ---------------------------------------------------------------------------
+
+const WEIGHTS = {
+  activity: 0.30,
+  velocity: 0.25,
+  community: 0.25,
+  security: 0.20,
+} as const;
+
+/**
+ * Compute the composite health score for a SafeProject.
+ *
+ * @param project  The project to score.
+ * @param now      Override "now" for deterministic tests (default: new Date()).
+ */
+export function computeHealth(project: SafeProject, now = new Date()): ProjectHealth {
+  const breakdown = {
+    activity: activityScore(project.lastCommitDate, now),
+    velocity: velocityScore(project.lastReleaseDate, now),
+    community: communityScore(project.contributors),
+    security: securityScore(project.lastAuditDate, project.cloMonitorName),
+  };
+
+  const raw =
+    breakdown.activity  * WEIGHTS.activity  +
+    breakdown.velocity  * WEIGHTS.velocity  +
+    breakdown.community * WEIGHTS.community +
+    breakdown.security  * WEIGHTS.security;
+
+  const score = Math.round(Math.min(100, Math.max(0, raw)));
+
+  return {
+    score,
+    grade: scoreToGrade(score),
+    breakdown,
+  };
+}

--- a/src/lib/projects/project-lightbox.ts
+++ b/src/lib/projects/project-lightbox.ts
@@ -1,0 +1,406 @@
+/**
+ * project-lightbox.ts
+ *
+ * Pure TypeScript renderer + runtime controller for the project detail lightbox.
+ * Returns an HTML string safe for direct innerHTML assignment.
+ *
+ * CSS namespace: plb2-*   (avoids collision with people plb-* namespace)
+ *
+ * Exports
+ * ───────
+ *  renderProjectLightboxContent(project, maintainers?, now?)  – pure renderer (testable)
+ *  openProjectLightbox(slug, base?)                           – lazy fetch + showModal
+ *  closeProjectLightbox()                                     – close dialog
+ *  initProjectLightbox()                                      – wire close/backdrop/Escape
+ */
+
+import type { SafeProject } from './project-renderer';
+import { computeHealth } from './project-health';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Maintainer {
+  name: string;
+  handle?: string;
+  avatarUrl?: string;
+  projects?: string[];
+  projectDetails?: Array<{ name: string; maturity?: string }>;
+  company?: string;
+  location?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
+/**
+ * Return a safe href attribute value: only allow http/https/mailto schemes.
+ * Anything else is replaced with '#'.
+ */
+export function safeHref(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.protocol === 'http:' || u.protocol === 'https:' || u.protocol === 'mailto:') {
+      return escapeHtml(url);
+    }
+  } catch {
+    // fall through
+  }
+  return '#';
+}
+
+export function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return escapeHtml(iso);
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+export function formatNumber(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
+  return String(n);
+}
+
+// ---------------------------------------------------------------------------
+// Maturity badge colours
+// ---------------------------------------------------------------------------
+
+const MATURITY_COLORS: Record<string, string> = {
+  graduated:  '#996600',
+  incubating: '#0060CC',
+  sandbox:    '#57606a',
+  archived:   '#6b7280',
+};
+
+// ---------------------------------------------------------------------------
+// Grade badge colours
+// ---------------------------------------------------------------------------
+
+const GRADE_COLORS: Record<string, string> = {
+  A: '#22863a',
+  B: '#0366d6',
+  C: '#e36209',
+  D: '#cb2431',
+};
+
+// ---------------------------------------------------------------------------
+// Section builders (all pure — no side effects)
+// ---------------------------------------------------------------------------
+
+function renderHeader(p: SafeProject): string {
+  const name = escapeHtml(p.name);
+  const maturity = p.maturity ?? 'sandbox';
+  const maturityColor = MATURITY_COLORS[maturity] ?? '#57606a';
+  const maturityLabel = maturity.charAt(0).toUpperCase() + maturity.slice(1);
+  const desc = p.description || p.summary || '';
+  const descHtml = desc
+    ? `<p class="plb2-description">${escapeHtml(desc)}</p>`
+    : '';
+
+  const logoHtml = p.logoUrl
+    ? `<img class="plb2-logo" src="${escapeHtml(p.logoUrl)}" alt="${name} logo" width="80" height="80" loading="lazy" />`
+    : `<div class="plb2-logo-placeholder" style="--plb2-color:${maturityColor}">${name.charAt(0)}</div>`;
+
+  const categoryMeta = p.category
+    ? `<span class="plb2-category">${escapeHtml(p.category)}${p.subcategory ? ` › ${escapeHtml(p.subcategory)}` : ''}</span>`
+    : '';
+
+  return `<div class="plb2-header">
+  <div class="plb2-logo-wrap">${logoHtml}</div>
+  <div class="plb2-header-info">
+    <div class="plb2-title-row">
+      <h2 class="plb2-title" id="project-modal-title">${name}</h2>
+      <span class="plb2-maturity-badge" style="--plb2-color:${maturityColor}">${maturityLabel}</span>
+    </div>
+    <div class="plb2-meta-row">${categoryMeta}</div>
+    ${descHtml}
+  </div>
+</div>`;
+}
+
+function renderHealthBar(p: SafeProject, now: Date): string {
+  const health = computeHealth(p, now);
+  const gradeColor = GRADE_COLORS[health.grade] ?? '#586069';
+
+  const auditPart = p.lastAuditDate
+    ? `<span class="plb2-health-item"><span class="plb2-health-label">Last audit:</span> ${escapeHtml(formatDate(p.lastAuditDate))}${p.lastAuditVendor ? ` (${escapeHtml(p.lastAuditVendor)})` : ''}</span>`
+    : '';
+
+  const cloLink = p.cloMonitorName
+    ? `<a class="plb2-health-link" href="https://clomonitor.io/projects/cncf/${escapeHtml(p.cloMonitorName)}" target="_blank" rel="noopener noreferrer">CLO Monitor</a>`
+    : '';
+
+  return `<div class="plb2-health-bar">
+  <span class="plb2-health-title">Health</span>
+  <span class="plb2-health-score-badge" style="background:${gradeColor};color:#fff;font-size:0.85rem;font-weight:700;padding:0.15rem 0.45rem;border-radius:4px">${health.score} / 100 ${health.grade}</span>
+  <span class="plb2-health-item" title="Activity">⚡ ${health.breakdown.activity}</span>
+  <span class="plb2-health-item" title="Velocity">🚀 ${health.breakdown.velocity}</span>
+  <span class="plb2-health-item" title="Community">👥 ${health.breakdown.community}</span>
+  <span class="plb2-health-item" title="Security">🔒 ${health.breakdown.security}</span>
+  ${auditPart}
+  ${cloLink}
+</div>`;
+}
+
+function renderStatsRow(p: SafeProject): string {
+  const items: string[] = [];
+  if (p.stars !== undefined && p.stars > 0)
+    items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">⭐</span><span class="plb2-stat-val">${formatNumber(p.stars)}</span><span class="plb2-stat-label">Stars</span></div>`);
+  if (p.forks !== undefined && p.forks > 0)
+    items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">🍴</span><span class="plb2-stat-val">${formatNumber(p.forks)}</span><span class="plb2-stat-label">Forks</span></div>`);
+  if (p.contributors !== undefined && p.contributors > 0)
+    items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">👥</span><span class="plb2-stat-val">${formatNumber(p.contributors)}</span><span class="plb2-stat-label">Contributors</span></div>`);
+  if (p.lastCommitDate)
+    items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">📅</span><span class="plb2-stat-val" style="font-size:0.75rem">${escapeHtml(formatDate(p.lastCommitDate))}</span><span class="plb2-stat-label">Last Commit</span></div>`);
+  if (p.primaryLanguage)
+    items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">💻</span><span class="plb2-stat-val" style="font-size:0.8125rem">${escapeHtml(p.primaryLanguage)}</span><span class="plb2-stat-label">Language</span></div>`);
+  if (p.license)
+    items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">📄</span><span class="plb2-stat-val" style="font-size:0.75rem">${escapeHtml(p.license)}</span><span class="plb2-stat-label">License</span></div>`);
+  if (items.length === 0) return '';
+  return `<div class="plb2-stats-row">${items.join('')}</div>`;
+}
+
+function renderSecurityLinks(p: SafeProject): string {
+  const links: string[] = [];
+  if (p.repoUrl) {
+    const ghPath = p.repoUrl.replace(/^https?:\/\/github\.com\//, '');
+    links.push(`<a class="plb2-security-link" href="https://scorecard.dev/viewer/?uri=github.com/${escapeHtml(ghPath)}" target="_blank" rel="noopener noreferrer">🔐 OpenSSF Scorecard</a>`);
+  }
+  if (p.cloMonitorName) {
+    links.push(`<a class="plb2-security-link" href="https://clomonitor.io/projects/cncf/${escapeHtml(p.cloMonitorName)}" target="_blank" rel="noopener noreferrer">🛡️ CLO Monitor</a>`);
+  }
+  if (links.length === 0) return '';
+  return `<div class="plb2-security-links">
+  <div class="plb2-section-label">Security</div>
+  <div class="plb2-link-chips">${links.join('')}</div>
+</div>`;
+}
+
+function renderContributorMinicards(p: SafeProject, maintainers: Maintainer[]): string {
+  // Cross-ref by project name (case-insensitive)
+  const projectName = p.name.toLowerCase();
+  const matched = maintainers.filter(m => {
+    if (m.projects?.some(proj => proj.toLowerCase() === projectName)) return true;
+    if (m.projectDetails?.some(pd => pd.name.toLowerCase() === projectName)) return true;
+    return false;
+  });
+
+  const shown = matched.slice(0, 6);
+
+  if (shown.length === 0) {
+    return `<div class="plb2-contributors">
+  <div class="plb2-section-label">Maintainers</div>
+  <p class="plb2-no-maintainers">No maintainers listed</p>
+</div>`;
+  }
+
+  const cards = shown.map(m => {
+    const name = escapeHtml(m.name);
+    const avatar = m.avatarUrl
+      ? `<img class="plb2-minicard-avatar" src="${escapeHtml(m.avatarUrl)}" alt="${name}" width="36" height="36" loading="lazy" />`
+      : `<div class="plb2-minicard-avatar-placeholder">${name.charAt(0)}</div>`;
+    const handleHref = m.handle
+      ? `href="https://github.com/${escapeHtml(m.handle)}" target="_blank" rel="noopener noreferrer"`
+      : '';
+    const handleText = m.handle ? `<span class="plb2-minicard-handle">@${escapeHtml(m.handle)}</span>` : '';
+    const tag = m.handle ? 'a' : 'div';
+    return `<${tag} class="plb2-minicard" ${handleHref}>
+  ${avatar}
+  <div class="plb2-minicard-info">
+    <span class="plb2-minicard-name">${name}</span>
+    ${handleText}
+  </div>
+</${tag}>`;
+  }).join('');
+
+  return `<div class="plb2-contributors">
+  <div class="plb2-section-label">Maintainers (${shown.length}${matched.length > 6 ? ` of ${matched.length}` : ''})</div>
+  <div class="plb2-minicards">${cards}</div>
+</div>`;
+}
+
+function renderEndUsers(p: SafeProject): string {
+  const slug = escapeHtml(p.cloMonitorName || p.slug || '');
+  const endUsersHref = `https://www.cncf.io/enduser/`;
+  return `<div class="plb2-endusers">
+  <div class="plb2-section-label">End Users</div>
+  <a class="plb2-endusers-link" href="${endUsersHref}" target="_blank" rel="noopener noreferrer">
+    🏢 CNCF End Users${slug ? ` using ${escapeHtml(p.name)}` : ''}
+  </a>
+</div>`;
+}
+
+function renderTopics(p: SafeProject): string {
+  if (!p.topics || p.topics.length === 0) return '';
+  const chips = p.topics.map(t =>
+    `<span class="plb2-topic-chip">${escapeHtml(t)}</span>`
+  ).join('');
+  return `<div class="plb2-topics">
+  <div class="plb2-section-label">Topics</div>
+  <div class="plb2-topic-chips">${chips}</div>
+</div>`;
+}
+
+function renderExternalLinks(p: SafeProject): string {
+  const links: string[] = [];
+  if (p.repoUrl)      links.push(`<a class="plb2-ext-link" href="${safeHref(p.repoUrl)}" target="_blank" rel="noopener noreferrer">🐙 GitHub</a>`);
+  if (p.homepageUrl)  links.push(`<a class="plb2-ext-link" href="${safeHref(p.homepageUrl)}" target="_blank" rel="noopener noreferrer">🌐 Website</a>`);
+  if (p.devStatsUrl)  links.push(`<a class="plb2-ext-link" href="${safeHref(p.devStatsUrl)}" target="_blank" rel="noopener noreferrer">📊 DevStats</a>`);
+  if (p.blogUrl)      links.push(`<a class="plb2-ext-link" href="${safeHref(p.blogUrl)}" target="_blank" rel="noopener noreferrer">📝 Blog</a>`);
+  if (p.twitterUrl)   links.push(`<a class="plb2-ext-link" href="${safeHref(p.twitterUrl)}" target="_blank" rel="noopener noreferrer">🐦 Twitter</a>`);
+  if (p.slackUrl)     links.push(`<a class="plb2-ext-link" href="${safeHref(p.slackUrl)}" target="_blank" rel="noopener noreferrer">💬 Slack</a>`);
+  if (p.lfxSlug)      links.push(`<a class="plb2-ext-link" href="https://insights.lfx.linuxfoundation.org/foundation/cncf/overview/github?project=${escapeHtml(p.lfxSlug)}" target="_blank" rel="noopener noreferrer">📈 LFX Insights</a>`);
+  if (links.length === 0) return '';
+  return `<div class="plb2-external-links">
+  <div class="plb2-section-label">Links</div>
+  <div class="plb2-link-chips">${links.join('')}</div>
+</div>`;
+}
+
+// ---------------------------------------------------------------------------
+// Main renderer export (pure — testable without DOM)
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the full HTML content for a project lightbox panel.
+ *
+ * @param project     The project to render.
+ * @param maintainers Maintainers array from maintainers.json (cross-ref by project name).
+ * @param now         Override "now" for deterministic health-score tests.
+ * @returns           Safe HTML string for innerHTML assignment.
+ */
+export function renderProjectLightboxContent(
+  project: SafeProject,
+  maintainers: Maintainer[] = [],
+  now = new Date(),
+): string {
+  return `<div class="plb2-content" data-slug="${escapeHtml(project.slug)}">
+  ${renderHeader(project)}
+  ${renderHealthBar(project, now)}
+  ${renderStatsRow(project)}
+  ${renderSecurityLinks(project)}
+  ${renderContributorMinicards(project, maintainers)}
+  ${renderEndUsers(project)}
+  ${renderTopics(project)}
+  ${renderExternalLinks(project)}
+</div>`;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime: lazy fetch + dialog controller
+// (browser-only — not called during Vitest)
+// ---------------------------------------------------------------------------
+
+let _projectsCache: SafeProject[] | null = null;
+let _maintainersCache: Maintainer[] | null = null;
+
+async function fetchProjects(base: string): Promise<SafeProject[]> {
+  if (_projectsCache) return _projectsCache;
+  const res = await fetch(`${base}/data/projects/projects.json`);
+  if (!res.ok) throw new Error(`Failed to fetch projects: ${res.status}`);
+  _projectsCache = (await res.json()) as SafeProject[];
+  return _projectsCache;
+}
+
+async function fetchMaintainers(base: string): Promise<Maintainer[]> {
+  if (_maintainersCache) return _maintainersCache;
+  try {
+    const res = await fetch(`${base}/data/people/maintainers.json`);
+    if (!res.ok) return [];
+    _maintainersCache = (await res.json()) as Maintainer[];
+    return _maintainersCache;
+  } catch {
+    return [];
+  }
+}
+
+function getDialog(): HTMLDialogElement | null {
+  return document.getElementById('project-modal') as HTMLDialogElement | null;
+}
+
+function getContent(): HTMLElement | null {
+  return document.getElementById('project-modal-content');
+}
+
+/**
+ * Close the project lightbox dialog.
+ */
+export function closeProjectLightbox(): void {
+  getDialog()?.close();
+}
+
+/**
+ * Open the project lightbox for the given slug.
+ * Lazily fetches projects.json and maintainers.json on first call.
+ */
+export async function openProjectLightbox(slug: string, base = ''): Promise<void> {
+  const dialog = getDialog();
+  const content = getContent();
+  if (!dialog || !content) return;
+
+  // Show loading state immediately
+  content.innerHTML = `<div class="plb2-loading" aria-live="polite" aria-label="Loading project details">
+  <span class="plb2-loading-spinner" aria-hidden="true">⏳</span>
+  <span>Loading…</span>
+</div>`;
+  dialog.showModal();
+
+  try {
+    const [projects, maintainers] = await Promise.all([
+      fetchProjects(base),
+      fetchMaintainers(base),
+    ]);
+
+    const project = projects.find(p => p.slug === slug);
+    if (!project) {
+      content.innerHTML = `<p class="plb2-error">Project "${escapeHtml(slug)}" not found.</p>`;
+      return;
+    }
+
+    content.innerHTML = renderProjectLightboxContent(project, maintainers);
+  } catch (err) {
+    content.innerHTML = `<p class="plb2-error">Failed to load project data. Please try again.</p>`;
+    console.error('[project-lightbox] fetch error:', err);
+  }
+}
+
+/**
+ * Wire up dialog close button, backdrop click, and Escape key.
+ * Call once on page load.
+ */
+export function initProjectLightbox(): void {
+  const dialog = getDialog();
+  if (!dialog) return;
+
+  // Close button
+  document.getElementById('project-modal-close')?.addEventListener('click', () => {
+    closeProjectLightbox();
+  });
+
+  // Backdrop click: the dialog element itself is the backdrop in native <dialog>.
+  // A click on the backdrop (but not the content box) has target === dialog.
+  dialog.addEventListener('click', (e: MouseEvent) => {
+    if (e.target === dialog) {
+      closeProjectLightbox();
+    }
+  });
+
+  // Escape key is handled natively by <dialog> — no extra wiring needed.
+  // We add a listener purely to allow tests / external code to hook in.
+  dialog.addEventListener('close', () => {
+    // Reset content after close animation
+    const content = getContent();
+    if (content) content.innerHTML = '';
+  });
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import ProjectsLayout from '../components/ProjectsLayout.astro';
+import ProjectLightbox from '../components/projects/ProjectLightbox.astro';
 import { formatRelativeDate } from '../lib/projects/project-renderer';
 import type { SafeProject } from '../lib/projects/project-renderer';
 import { selectHeroSets } from '../lib/projects/heroes';
@@ -183,6 +184,7 @@ function formatNumber(n: number): string {
   {includeEmbeddedData && (
     <script slot="body-end" type="application/json" id="initial-changelog-data" set:html={JSON.stringify(changelogEvents.slice(0, 100))}></script>
   )}
+  <ProjectLightbox />
 </ProjectsLayout>
 
 <script>
@@ -194,6 +196,7 @@ function formatNumber(n: number): string {
   import { initSearch, searchProjects } from '../lib/projects/search';
   import { initKeyboard } from '../lib/keyboard';
   import { fireFountain, preloadOnHover, fireHearts } from '../lib/confetti';
+  import { initProjectLightbox, openProjectLightbox } from '../lib/projects/project-lightbox';
 
   const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   let allProjects: SafeProject[] = [];
@@ -346,7 +349,13 @@ function formatNumber(n: number): string {
       if (card.dataset.eventsWired === '1') return;
       card.dataset.eventsWired = '1';
       preloadOnHover(card);
-      card.addEventListener('click', () => fireHearts(card));
+      card.addEventListener('click', (e) => {
+        // Don't open lightbox if user clicked a link inside the card
+        if ((e.target as HTMLElement).closest('a')) return;
+        fireHearts(card);
+        const slug = card.dataset.slug ?? '';
+        if (slug) openProjectLightbox(slug, base);
+      });
     });
   }
 
@@ -377,6 +386,7 @@ function formatNumber(n: number): string {
   }
 
   hydrateEmbeddedData();
+  initProjectLightbox();
   renderCurrentView();
   const isLocalDev = window.location.hostname === 'localhost';
   if (!isLocalDev || allProjects.length === 0) {

--- a/tests/unit/projects/project-health.test.ts
+++ b/tests/unit/projects/project-health.test.ts
@@ -1,0 +1,360 @@
+/**
+ * tests/unit/projects/project-health.test.ts
+ *
+ * Vitest unit tests for src/lib/projects/project-health.ts
+ * Target: ≥70% statement/branch coverage.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  activityScore,
+  velocityScore,
+  communityScore,
+  securityScore,
+  scoreToGrade,
+  computeHealth,
+  type ProjectHealth,
+  type HealthGrade,
+} from '../../../src/lib/projects/project-health';
+import type { SafeProject } from '../../../src/lib/projects/project-renderer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a date that is `days` days in the past relative to `now`. */
+function daysAgo(days: number, now = new Date()): string {
+  return new Date(now.getTime() - days * 86_400_000).toISOString();
+}
+
+const NOW = new Date('2026-01-01T00:00:00Z');
+
+/** Minimal valid SafeProject for test purposes. */
+const BASE_PROJECT: SafeProject = {
+  name: 'TestProject',
+  slug: 'testproject',
+  maturity: 'graduated',
+  category: 'Test Category',
+  subcategory: 'Sub',
+  logoUrl: 'https://example.com/logo.svg',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// activityScore
+// ---------------------------------------------------------------------------
+
+describe('activityScore', () => {
+  it('returns 100 for a commit today', () => {
+    expect(activityScore(NOW.toISOString(), NOW)).toBe(100);
+  });
+
+  it('returns ~50 for a commit 182 days ago', () => {
+    const score = activityScore(daysAgo(182, NOW), NOW);
+    expect(score).toBeGreaterThanOrEqual(48);
+    expect(score).toBeLessThanOrEqual(52);
+  });
+
+  it('returns 0 for a commit exactly 365 days ago', () => {
+    expect(activityScore(daysAgo(365, NOW), NOW)).toBe(0);
+  });
+
+  it('returns 0 for a commit more than 365 days ago', () => {
+    expect(activityScore(daysAgo(400, NOW), NOW)).toBe(0);
+  });
+
+  it('returns 0 when lastCommitDate is undefined', () => {
+    expect(activityScore(undefined, NOW)).toBe(0);
+  });
+
+  it('returns 0 for an invalid date string', () => {
+    expect(activityScore('not-a-date', NOW)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// velocityScore
+// ---------------------------------------------------------------------------
+
+describe('velocityScore', () => {
+  it('returns 100 for a release today', () => {
+    expect(velocityScore(NOW.toISOString(), NOW)).toBe(100);
+  });
+
+  it('returns ~50 for a release 182 days ago', () => {
+    const score = velocityScore(daysAgo(182, NOW), NOW);
+    expect(score).toBeGreaterThanOrEqual(48);
+    expect(score).toBeLessThanOrEqual(52);
+  });
+
+  it('returns 0 for a release exactly 365 days ago', () => {
+    expect(velocityScore(daysAgo(365, NOW), NOW)).toBe(0);
+  });
+
+  it('returns 0 when lastReleaseDate is undefined', () => {
+    expect(velocityScore(undefined, NOW)).toBe(0);
+  });
+
+  it('returns 0 for an invalid date string', () => {
+    expect(velocityScore('bad-date', NOW)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// communityScore
+// ---------------------------------------------------------------------------
+
+describe('communityScore', () => {
+  it('returns 0 for 0 contributors', () => {
+    expect(communityScore(0)).toBe(0);
+  });
+
+  it('returns 0 for undefined contributors', () => {
+    expect(communityScore(undefined)).toBe(0);
+  });
+
+  it('returns 0 for negative contributors', () => {
+    expect(communityScore(-5)).toBe(0);
+  });
+
+  it('returns 100 for exactly 1000 contributors', () => {
+    expect(communityScore(1000)).toBe(100);
+  });
+
+  it('returns 100 for more than 1000 contributors', () => {
+    expect(communityScore(5000)).toBe(100);
+  });
+
+  it('returns roughly 67 for 100 contributors (log(100)/log(1000) ≈ 0.667)', () => {
+    const score = communityScore(100);
+    expect(score).toBeGreaterThanOrEqual(66);
+    expect(score).toBeLessThanOrEqual(68);
+  });
+
+  it('returns roughly 33 for 10 contributors (log(10)/log(1000) ≈ 0.333)', () => {
+    const score = communityScore(10);
+    expect(score).toBeGreaterThanOrEqual(32);
+    expect(score).toBeLessThanOrEqual(34);
+  });
+
+  it('returns > 0 for 1 contributor', () => {
+    // log(1)/log(1000) = 0 → score should be 0
+    expect(communityScore(1)).toBe(0);
+  });
+
+  it('returns > 0 for 2 contributors', () => {
+    expect(communityScore(2)).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// securityScore
+// ---------------------------------------------------------------------------
+
+describe('securityScore', () => {
+  it('returns 0 with no audit and no CLO Monitor', () => {
+    expect(securityScore(undefined, undefined)).toBe(0);
+  });
+
+  it('returns 50 with only a valid audit date', () => {
+    expect(securityScore('2024-01-01', undefined)).toBe(50);
+  });
+
+  it('returns 50 with only a cloMonitorName', () => {
+    expect(securityScore(undefined, 'my-project')).toBe(50);
+  });
+
+  it('returns 100 with both audit date and cloMonitorName', () => {
+    expect(securityScore('2024-01-01', 'my-project')).toBe(100);
+  });
+
+  it('treats empty-string audit date as absent', () => {
+    expect(securityScore('', 'my-project')).toBe(50);
+  });
+
+  it('treats whitespace-only audit date as absent', () => {
+    expect(securityScore('   ', undefined)).toBe(0);
+  });
+
+  it('treats empty-string cloMonitorName as absent', () => {
+    expect(securityScore('2024-01-01', '')).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreToGrade
+// ---------------------------------------------------------------------------
+
+describe('scoreToGrade', () => {
+  it('returns A for score 80', () => {
+    expect(scoreToGrade(80)).toBe('A');
+  });
+
+  it('returns A for score 100', () => {
+    expect(scoreToGrade(100)).toBe('A');
+  });
+
+  it('returns B for score 60', () => {
+    expect(scoreToGrade(60)).toBe('B');
+  });
+
+  it('returns B for score 79', () => {
+    expect(scoreToGrade(79)).toBe('B');
+  });
+
+  it('returns C for score 40', () => {
+    expect(scoreToGrade(40)).toBe('C');
+  });
+
+  it('returns C for score 59', () => {
+    expect(scoreToGrade(59)).toBe('C');
+  });
+
+  it('returns D for score 0', () => {
+    expect(scoreToGrade(0)).toBe('D');
+  });
+
+  it('returns D for score 39', () => {
+    expect(scoreToGrade(39)).toBe('D');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeHealth — composite score
+// ---------------------------------------------------------------------------
+
+describe('computeHealth', () => {
+  it('returns a score and grade for a fully-populated project', () => {
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      lastCommitDate: daysAgo(10, NOW),
+      lastReleaseDate: daysAgo(20, NOW),
+      contributors: 500,
+      lastAuditDate: '2025-06-01',
+      cloMonitorName: 'testproject',
+    };
+    const health = computeHealth(project, NOW);
+    expect(health.score).toBeGreaterThan(0);
+    expect(health.score).toBeLessThanOrEqual(100);
+    expect(['A', 'B', 'C', 'D']).toContain(health.grade);
+  });
+
+  it('returns score 0 for a project with no optional fields', () => {
+    const health = computeHealth(BASE_PROJECT, NOW);
+    expect(health.score).toBe(0);
+    expect(health.grade).toBe('D');
+    expect(health.breakdown.activity).toBe(0);
+    expect(health.breakdown.velocity).toBe(0);
+    expect(health.breakdown.community).toBe(0);
+    expect(health.breakdown.security).toBe(0);
+  });
+
+  it('returns grade A for a near-perfect project', () => {
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      lastCommitDate: daysAgo(1, NOW),
+      lastReleaseDate: daysAgo(1, NOW),
+      contributors: 1000,
+      lastAuditDate: '2025-12-01',
+      cloMonitorName: 'testproject',
+    };
+    const health = computeHealth(project, NOW);
+    expect(health.grade).toBe('A');
+    expect(health.score).toBeGreaterThanOrEqual(80);
+  });
+
+  it('score is clamped to [0, 100]', () => {
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      lastCommitDate: daysAgo(1, NOW),
+      lastReleaseDate: daysAgo(1, NOW),
+      contributors: 9999999,
+      lastAuditDate: '2025-12-01',
+      cloMonitorName: 'testproject',
+    };
+    const health = computeHealth(project, NOW);
+    expect(health.score).toBeLessThanOrEqual(100);
+    expect(health.score).toBeGreaterThanOrEqual(0);
+  });
+
+  it('breakdown activity weight is 30%', () => {
+    // Only activity contributes — commit today, no other fields
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      lastCommitDate: NOW.toISOString(),
+    };
+    const health = computeHealth(project, NOW);
+    // activity=100, velocity=0, community=0, security=0
+    // composite = 100 * 0.30 = 30
+    expect(health.breakdown.activity).toBe(100);
+    expect(health.score).toBe(30);
+  });
+
+  it('breakdown velocity weight is 25%', () => {
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      lastReleaseDate: NOW.toISOString(),
+    };
+    const health = computeHealth(project, NOW);
+    expect(health.breakdown.velocity).toBe(100);
+    expect(health.score).toBe(25);
+  });
+
+  it('breakdown community weight is 25%', () => {
+    // 1000 contributors → community=100
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      contributors: 1000,
+    };
+    const health = computeHealth(project, NOW);
+    expect(health.breakdown.community).toBe(100);
+    expect(health.score).toBe(25);
+  });
+
+  it('breakdown security weight is 20%', () => {
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      lastAuditDate: '2025-01-01',
+      cloMonitorName: 'testproject',
+    };
+    const health = computeHealth(project, NOW);
+    expect(health.breakdown.security).toBe(100);
+    expect(health.score).toBe(20);
+  });
+
+  it('grade matches scoreToGrade(score)', () => {
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      lastCommitDate: daysAgo(30, NOW),
+      contributors: 50,
+    };
+    const health = computeHealth(project, NOW);
+    expect(health.grade).toBe(scoreToGrade(health.score));
+  });
+
+  it('handles a project committed exactly 365 days ago', () => {
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      lastCommitDate: daysAgo(365, NOW),
+    };
+    const health = computeHealth(project, NOW);
+    expect(health.breakdown.activity).toBe(0);
+  });
+
+  it('uses default now when not provided', () => {
+    // Just ensure no error thrown when `now` omitted
+    const health = computeHealth(BASE_PROJECT);
+    expect(typeof health.score).toBe('number');
+  });
+
+  it('returns integer score', () => {
+    const project: SafeProject = {
+      ...BASE_PROJECT,
+      lastCommitDate: daysAgo(100, NOW),
+      lastReleaseDate: daysAgo(50, NOW),
+      contributors: 123,
+    };
+    const health = computeHealth(project, NOW);
+    expect(Number.isInteger(health.score)).toBe(true);
+  });
+});

--- a/tests/unit/projects/project-lightbox.test.ts
+++ b/tests/unit/projects/project-lightbox.test.ts
@@ -1,0 +1,378 @@
+/**
+ * tests/unit/projects/project-lightbox.test.ts
+ *
+ * Vitest unit tests for src/lib/projects/project-lightbox.ts
+ *
+ * Covers the pure renderProjectLightboxContent() renderer and
+ * utility helpers (escapeHtml, safeHref, formatNumber, formatDate).
+ * DOM-dependent functions (openProjectLightbox, closeProjectLightbox,
+ * initProjectLightbox) are not tested here — they are exercised by the
+ * Playwright e2e suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  renderProjectLightboxContent,
+  escapeHtml,
+  safeHref,
+  formatNumber,
+  formatDate,
+  type Maintainer,
+} from '../../../src/lib/projects/project-lightbox';
+import type { SafeProject } from '../../../src/lib/projects/project-renderer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOW = new Date('2026-01-01T00:00:00Z');
+
+/** Minimal valid SafeProject. */
+const BASE_PROJECT: SafeProject = {
+  name: 'TestProject',
+  slug: 'testproject',
+  maturity: 'graduated',
+  category: 'Test Category',
+  subcategory: 'Sub',
+  logoUrl: 'https://example.com/logo.svg',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+/** A richer project fixture for integration-style rendering tests. */
+const FULL_PROJECT: SafeProject = {
+  name: 'Kyverno',
+  slug: 'kyverno',
+  description: 'Policy as code for Kubernetes',
+  homepageUrl: 'https://kyverno.io/',
+  repoUrl: 'https://github.com/kyverno/kyverno',
+  logoUrl: 'https://landscape.cncf.io/logos/kyverno.svg',
+  maturity: 'graduated',
+  category: 'Provisioning',
+  subcategory: 'Security & Compliance',
+  twitterUrl: 'https://twitter.com/kyverno',
+  devStatsUrl: 'https://kyverno.devstats.cncf.io/',
+  slackUrl: 'https://kubernetes.slack.com/',
+  lfxSlug: 'kyverno',
+  cloMonitorName: 'kyverno',
+  stars: 7578,
+  forks: 1296,
+  contributors: 501,
+  lastCommitDate: '2026-01-01T00:00:00Z',
+  lastReleaseDate: '2025-12-01T00:00:00Z',
+  license: 'Apache License 2.0',
+  primaryLanguage: 'Go',
+  topics: ['kubernetes', 'policy-as-code', 'security'],
+  lastAuditDate: '2023-11-28',
+  lastAuditVendor: 'Ada Logics',
+  acceptedDate: '2020-11-10',
+  incubatingDate: '2022-07-13',
+  graduatedDate: '2026-03-16',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const MAINTAINER_KYVERNO: Maintainer = {
+  name: 'Jim Bugwadia',
+  handle: 'jimbugwadia',
+  avatarUrl: 'https://avatars.githubusercontent.com/jimbugwadia',
+  projects: ['Kyverno'],
+  projectDetails: [{ name: 'Kyverno', maturity: 'Graduated' }],
+  company: 'Nirmata',
+};
+
+const MAINTAINER_OTHER: Maintainer = {
+  name: 'Other Person',
+  handle: 'otherperson',
+  projects: ['Argo'],
+  projectDetails: [{ name: 'Argo', maturity: 'Graduated' }],
+};
+
+// ---------------------------------------------------------------------------
+// Utility tests
+// ---------------------------------------------------------------------------
+
+describe('escapeHtml', () => {
+  it('escapes ampersands', () => {
+    expect(escapeHtml('a&b')).toBe('a&amp;b');
+  });
+
+  it('escapes angle brackets', () => {
+    expect(escapeHtml('<script>')).toBe('&lt;script&gt;');
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeHtml('"hello"')).toBe('&quot;hello&quot;');
+  });
+
+  it('escapes single quotes', () => {
+    expect(escapeHtml("it's")).toBe('it&#x27;s');
+  });
+
+  it('passes through safe strings unchanged', () => {
+    expect(escapeHtml('hello world 123')).toBe('hello world 123');
+  });
+});
+
+describe('safeHref', () => {
+  it('allows https URLs', () => {
+    expect(safeHref('https://example.com')).toBe('https://example.com');
+  });
+
+  it('allows http URLs', () => {
+    expect(safeHref('http://example.com')).toBe('http://example.com');
+  });
+
+  it('allows mailto URLs', () => {
+    expect(safeHref('mailto:user@example.com')).toBe('mailto:user@example.com');
+  });
+
+  it('blocks javascript: protocol', () => {
+    expect(safeHref('javascript:alert(1)')).toBe('#');
+  });
+
+  it('blocks data: protocol', () => {
+    expect(safeHref('data:text/html,<h1>pwned</h1>')).toBe('#');
+  });
+
+  it('blocks invalid URLs', () => {
+    expect(safeHref('not a url')).toBe('#');
+  });
+
+  it('escapes special chars in valid URLs', () => {
+    const result = safeHref('https://example.com/foo?a=1&b=2');
+    expect(result).toContain('&amp;');
+  });
+});
+
+describe('formatNumber', () => {
+  it('formats numbers < 1000 as-is', () => {
+    expect(formatNumber(999)).toBe('999');
+    expect(formatNumber(0)).toBe('0');
+  });
+
+  it('formats thousands with k suffix', () => {
+    expect(formatNumber(1000)).toBe('1.0k');
+    expect(formatNumber(7578)).toBe('7.6k');
+    expect(formatNumber(1500)).toBe('1.5k');
+  });
+
+  it('formats millions with M suffix', () => {
+    expect(formatNumber(1_000_000)).toBe('1.0M');
+    expect(formatNumber(2_500_000)).toBe('2.5M');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats a valid ISO date string', () => {
+    const result = formatDate('2023-11-28T00:00:00Z');
+    expect(result).toContain('2023');
+    expect(result).toContain('Nov');
+  });
+
+  it('formats a date-only string', () => {
+    const result = formatDate('2020-11-10');
+    expect(result).toContain('2020');
+  });
+
+  it('returns the escaped input for invalid dates', () => {
+    const result = formatDate('not-a-date');
+    expect(result).toBe('not-a-date'); // escapeHtml of "not-a-date" = itself
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderProjectLightboxContent — structural checks
+// ---------------------------------------------------------------------------
+
+describe('renderProjectLightboxContent', () => {
+  it('returns a non-empty HTML string', () => {
+    const html = renderProjectLightboxContent(BASE_PROJECT, [], NOW);
+    expect(typeof html).toBe('string');
+    expect(html.length).toBeGreaterThan(0);
+  });
+
+  it('wraps content in .plb2-content with data-slug', () => {
+    const html = renderProjectLightboxContent(BASE_PROJECT, [], NOW);
+    expect(html).toContain('class="plb2-content"');
+    expect(html).toContain('data-slug="testproject"');
+  });
+
+  it('includes project name in h2#project-modal-title', () => {
+    const html = renderProjectLightboxContent(BASE_PROJECT, [], NOW);
+    expect(html).toContain('id="project-modal-title"');
+    expect(html).toContain('TestProject');
+  });
+
+  it('escapes XSS in project name', () => {
+    const xss: SafeProject = {
+      ...BASE_PROJECT,
+      name: '<script>alert(1)</script>',
+      slug: 'xss-test',
+    };
+    const html = renderProjectLightboxContent(xss, [], NOW);
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('shows maturity badge', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('plb2-maturity-badge');
+    expect(html).toContain('Graduated');
+  });
+
+  it('shows description when present', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('Policy as code for Kubernetes');
+  });
+
+  it('falls back to summary when description is absent', () => {
+    const p: SafeProject = {
+      ...BASE_PROJECT,
+      summary: 'Summary text here',
+    };
+    const html = renderProjectLightboxContent(p, [], NOW);
+    expect(html).toContain('Summary text here');
+  });
+
+  it('renders stats row with formatted numbers', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('plb2-stats-row');
+    // 7578 stars → 7.6k
+    expect(html).toContain('7.6k');
+  });
+
+  it('renders topics chips when topics array is non-empty', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('plb2-topic-chip');
+    expect(html).toContain('kubernetes');
+    expect(html).toContain('policy-as-code');
+  });
+
+  it('renders no topics section when topics is empty', () => {
+    const p: SafeProject = { ...BASE_PROJECT, topics: [] };
+    const html = renderProjectLightboxContent(p, [], NOW);
+    expect(html).not.toContain('plb2-topic-chip');
+  });
+
+  it('renders external links when repoUrl is present', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('plb2-ext-link');
+    expect(html).toContain('GitHub');
+  });
+
+  it('renders CLO Monitor link when cloMonitorName present', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('clomonitor.io/projects/cncf/kyverno');
+  });
+
+  it('renders health bar with score', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('plb2-health-bar');
+    expect(html).toContain('/ 100');
+  });
+
+  it('renders last audit info when present', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('Ada Logics');
+  });
+
+  it('renders end users section', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('plb2-endusers');
+    expect(html).toContain('CNCF End Users');
+  });
+
+  it('renders LFX Insights link when lfxSlug present', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('insights.lfx.linuxfoundation.org');
+  });
+
+  it('renders OpenSSF Scorecard link when repoUrl is a GitHub URL', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('scorecard.dev');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contributor minicards
+// ---------------------------------------------------------------------------
+
+describe('renderProjectLightboxContent — contributor minicards', () => {
+  it('shows matched maintainer minicard', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [MAINTAINER_KYVERNO], NOW);
+    expect(html).toContain('Jim Bugwadia');
+    expect(html).toContain('jimbugwadia');
+  });
+
+  it('does NOT show unrelated maintainer', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [MAINTAINER_OTHER], NOW);
+    expect(html).not.toContain('Other Person');
+  });
+
+  it('shows fallback when no maintainers match', () => {
+    const html = renderProjectLightboxContent(BASE_PROJECT, [], NOW);
+    expect(html).toContain('No maintainers listed');
+  });
+
+  it('shows up to 6 minicards', () => {
+    const many: Maintainer[] = Array.from({ length: 10 }, (_, i) => ({
+      name: `Maintainer ${i}`,
+      handle: `handle${i}`,
+      projects: ['TestProject'],
+    }));
+    const html = renderProjectLightboxContent(BASE_PROJECT, many, NOW);
+    const count = (html.match(/plb2-minicard"/g) ?? []).length;
+    expect(count).toBe(6);
+  });
+
+  it('uses projectDetails cross-ref when projects[] is absent', () => {
+    const m: Maintainer = {
+      name: 'Detail Only',
+      handle: 'detailonly',
+      projectDetails: [{ name: 'TestProject', maturity: 'Graduated' }],
+    };
+    const html = renderProjectLightboxContent(BASE_PROJECT, [m], NOW);
+    expect(html).toContain('Detail Only');
+  });
+
+  it('cross-ref is case-insensitive', () => {
+    const m: Maintainer = {
+      name: 'Case Insensitive',
+      handle: 'ci',
+      projects: ['TESTPROJECT'], // uppercase
+    };
+    const html = renderProjectLightboxContent(BASE_PROJECT, [m], NOW);
+    expect(html).toContain('Case Insensitive');
+  });
+
+  it('renders logo image when logoUrl is present', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('plb2-logo');
+    expect(html).toContain('kyverno.svg');
+  });
+
+  it('renders placeholder when logoUrl is absent', () => {
+    const p: SafeProject = { ...BASE_PROJECT, logoUrl: '' };
+    const html = renderProjectLightboxContent(p, [], NOW);
+    expect(html).toContain('plb2-logo-placeholder');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sandbox / incubating maturity colours
+// ---------------------------------------------------------------------------
+
+describe('renderProjectLightboxContent — maturity badge colors', () => {
+  it('uses incubating color for incubating projects', () => {
+    const p: SafeProject = { ...BASE_PROJECT, maturity: 'incubating' };
+    const html = renderProjectLightboxContent(p, [], NOW);
+    expect(html).toContain('#0060CC'); // incubating color
+    expect(html).toContain('Incubating');
+  });
+
+  it('uses sandbox color for sandbox projects', () => {
+    const p: SafeProject = { ...BASE_PROJECT, maturity: 'sandbox' };
+    const html = renderProjectLightboxContent(p, [], NOW);
+    expect(html).toContain('#57606a');
+    expect(html).toContain('Sandbox');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `ProjectLightbox.astro` component (dialog shell with `plb2-*` CSS namespace)
- Wires `<ProjectLightbox />` into `src/pages/index.astro`
- Imports `initProjectLightbox` and `openProjectLightbox` from `project-lightbox.ts`
- Hero cards already have `data-slug` attribute; click handler now opens lightbox (skips clicks on inner `<a>` elements)
- `npx tsc --noEmit` passes clean

## Test plan
- [ ] Click a hero card on the projects index — lightbox should open with project details
- [ ] Click the project name link inside a hero card — lightbox should NOT open (link navigates normally)
- [ ] Press Escape to close lightbox
- [ ] Click backdrop to close lightbox
- [ ] Verify close button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)