### PR TITLE
Surface real OpenSSF Scorecard score in project hero lightbox

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -60,6 +60,7 @@ copy-data-to-public:
     @mkdir -p public/data/projects public/data/members public/data/people
     @cp src/data/projects/projects.json public/data/projects/ 2>/dev/null || true
     @cp src/data/projects/changelog.json public/data/projects/ 2>/dev/null || true
+    @cp src/data/projects/openssf-scores.json public/data/projects/ 2>/dev/null || true
     @cp src/data/members/members.json public/data/members/ 2>/dev/null || true
     @cp src/data/members/changelog.json public/data/members/ 2>/dev/null || true
     @cp src/data/members/architectures.json public/data/members/ 2>/dev/null || true

--- a/src/components/projects/ProjectLightbox.astro
+++ b/src/components/projects/ProjectLightbox.astro
@@ -338,6 +338,31 @@
   text-decoration: none;
 }
 
+/* ─── OpenSSF Scorecard badge + failing checks ───────────────────────────── */
+:global(.plb2-scorecard-badge) {
+  border-color: color-mix(in srgb, var(--plb2-score-color, #57606a) 45%, transparent);
+  color: var(--plb2-score-color, inherit);
+}
+:global(.plb2-scorecard-badge:hover) {
+  border-color: var(--plb2-score-color, #0969da);
+  background: color-mix(in srgb, var(--plb2-score-color, #888) 10%, transparent);
+}
+
+:global(.plb2-scorecard-checks) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+:global(.plb2-scorecard-check) {
+  font-size: 0.6875rem;
+  padding: 0.15rem 0.45rem;
+  background: var(--color-bg-tertiary, #eaeef2);
+  color: var(--color-text-secondary, #57606a);
+  border-radius: 10px;
+  border: 1px solid var(--color-border-default, #d0d7de);
+}
+
 /* ─── Contributor minicards ──────────────────────────────────────────────── */
 :global(.plb2-minicards) {
   display: flex;

--- a/src/lib/projects/project-lightbox.ts
+++ b/src/lib/projects/project-lightbox.ts
@@ -31,6 +31,28 @@ export interface Maintainer {
   location?: string;
 }
 
+/** A single OpenSSF Scorecard check result (mirrors go/internal/scorecard). */
+export interface ScorecardCheck {
+  name: string;
+  score: number;
+  reason?: string;
+}
+
+/**
+ * A project's enriched OpenSSF Scorecard entry, as written to
+ * src/data/projects/openssf-scores.json by `go run ./cmd/enrich`.
+ * The map is keyed by project slug.
+ */
+export interface ScorecardEntry {
+  repo: string;
+  score: number;
+  date?: string;
+  checks?: ScorecardCheck[];
+  fetchedAt?: string;
+}
+
+export type ScorecardMap = Record<string, ScorecardEntry>;
+
 // ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
@@ -171,19 +193,47 @@ function renderStatsRow(p: SafeProject): string {
   return `<div class="plb2-stats-row">${items.join('')}</div>`;
 }
 
-function renderSecurityLinks(p: SafeProject): string {
+/**
+ * Colour for an OpenSSF Scorecard score (0–10 scale).
+ * Mirrors the upstream scorecard.dev viewer's traffic-light convention.
+ */
+function scorecardColor(score: number): string {
+  if (score >= 7) return '#22863a';
+  if (score >= 4) return '#e36209';
+  return '#cb2431';
+}
+
+function renderSecurityLinks(p: SafeProject, scorecard?: ScorecardEntry): string {
   const links: string[] = [];
   if (p.repoUrl) {
     const ghPath = p.repoUrl.replace(/^https?:\/\/github\.com\//, '');
-    links.push(`<a class="plb2-security-link" href="https://scorecard.dev/viewer/?uri=github.com/${escapeHtml(ghPath)}" target="_blank" rel="noopener noreferrer">🔐 OpenSSF Scorecard</a>`);
+    const scorecardHref = `https://scorecard.dev/viewer/?uri=github.com/${escapeHtml(ghPath)}`;
+    if (scorecard && typeof scorecard.score === 'number') {
+      const color = scorecardColor(scorecard.score);
+      links.push(`<a class="plb2-security-link plb2-scorecard-badge" style="--plb2-score-color:${color}" href="${scorecardHref}" target="_blank" rel="noopener noreferrer">🔐 OpenSSF Scorecard: <strong>${scorecard.score.toFixed(1)}</strong>/10</a>`);
+    } else {
+      links.push(`<a class="plb2-security-link" href="${scorecardHref}" target="_blank" rel="noopener noreferrer">🔐 OpenSSF Scorecard</a>`);
+    }
   }
   if (p.cloMonitorName) {
     links.push(`<a class="plb2-security-link" href="https://clomonitor.io/projects/cncf/${escapeHtml(p.cloMonitorName)}" target="_blank" rel="noopener noreferrer">🛡️ CLO Monitor</a>`);
   }
   if (links.length === 0) return '';
+
+  const lowChecks = (scorecard?.checks ?? [])
+    .filter(c => typeof c.score === 'number' && c.score >= 0 && c.score < 7)
+    .sort((a, b) => a.score - b.score)
+    .slice(0, 4);
+  const checksHtml = lowChecks.length
+    ? `<div class="plb2-scorecard-checks">${lowChecks.map(c =>
+        `<span class="plb2-scorecard-check" title="${escapeHtml(c.reason || '')}">${escapeHtml(c.name)}: ${c.score}/10</span>`
+      ).join('')}</div>`
+    : '';
+
   return `<div class="plb2-security-links">
   <div class="plb2-section-label">Security</div>
   <div class="plb2-link-chips">${links.join('')}</div>
+  ${checksHtml}
 </div>`;
 }
 
@@ -284,12 +334,13 @@ export function renderProjectLightboxContent(
   project: SafeProject,
   maintainers: Maintainer[] = [],
   now = new Date(),
+  scorecard?: ScorecardEntry,
 ): string {
   return `<div class="plb2-content" data-slug="${escapeHtml(project.slug)}">
   ${renderHeader(project)}
   ${renderHealthBar(project, now)}
   ${renderStatsRow(project)}
-  ${renderSecurityLinks(project)}
+  ${renderSecurityLinks(project, scorecard)}
   ${renderContributorMinicards(project, maintainers)}
   ${renderEndUsers(project)}
   ${renderTopics(project)}
@@ -304,6 +355,7 @@ export function renderProjectLightboxContent(
 
 let _projectsCache: SafeProject[] | null = null;
 let _maintainersCache: Maintainer[] | null = null;
+let _scorecardCache: ScorecardMap | null = null;
 
 async function fetchProjects(base: string): Promise<SafeProject[]> {
   if (_projectsCache) return _projectsCache;
@@ -325,6 +377,24 @@ async function fetchMaintainers(base: string): Promise<Maintainer[]> {
   }
 }
 
+/**
+ * Fetch the OpenSSF Scorecard enrichment map (openssf-scores.json), keyed by
+ * project slug. Written by `just enrich-projects` / `go run ./cmd/enrich`.
+ * Missing or unreadable file is not an error — the lightbox degrades to
+ * showing a plain link instead of a numeric score.
+ */
+async function fetchScorecard(base: string): Promise<ScorecardMap> {
+  if (_scorecardCache) return _scorecardCache;
+  try {
+    const res = await fetch(`${base}/data/projects/openssf-scores.json`);
+    if (!res.ok) return {};
+    _scorecardCache = (await res.json()) as ScorecardMap;
+    return _scorecardCache;
+  } catch {
+    return {};
+  }
+}
+
 function getDialog(): HTMLDialogElement | null {
   return document.getElementById('project-modal') as HTMLDialogElement | null;
 }
@@ -342,7 +412,8 @@ export function closeProjectLightbox(): void {
 
 /**
  * Open the project lightbox for the given slug.
- * Lazily fetches projects.json and maintainers.json on first call.
+ * Lazily fetches projects.json, maintainers.json, and openssf-scores.json
+ * on first call.
  */
 export async function openProjectLightbox(slug: string, base = ''): Promise<void> {
   const dialog = getDialog();
@@ -357,9 +428,10 @@ export async function openProjectLightbox(slug: string, base = ''): Promise<void
   dialog.showModal();
 
   try {
-    const [projects, maintainers] = await Promise.all([
+    const [projects, maintainers, scorecardMap] = await Promise.all([
       fetchProjects(base),
       fetchMaintainers(base),
+      fetchScorecard(base),
     ]);
 
     const project = projects.find(p => p.slug === slug);
@@ -368,7 +440,7 @@ export async function openProjectLightbox(slug: string, base = ''): Promise<void
       return;
     }
 
-    content.innerHTML = renderProjectLightboxContent(project, maintainers);
+    content.innerHTML = renderProjectLightboxContent(project, maintainers, new Date(), scorecardMap[slug]);
   } catch (err) {
     content.innerHTML = `<p class="plb2-error">Failed to load project data. Please try again.</p>`;
     console.error('[project-lightbox] fetch error:', err);

--- a/tests/unit/projects/project-lightbox.test.ts
+++ b/tests/unit/projects/project-lightbox.test.ts
@@ -18,6 +18,7 @@ import {
   formatNumber,
   formatDate,
   type Maintainer,
+  type ScorecardEntry,
 } from '../../../src/lib/projects/project-lightbox';
 import type { SafeProject } from '../../../src/lib/projects/project-renderer';
 
@@ -374,5 +375,75 @@ describe('renderProjectLightboxContent — maturity badge colors', () => {
     const html = renderProjectLightboxContent(p, [], NOW);
     expect(html).toContain('#57606a');
     expect(html).toContain('Sandbox');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenSSF Scorecard enrichment
+// ---------------------------------------------------------------------------
+
+describe('renderProjectLightboxContent — OpenSSF Scorecard', () => {
+  const HIGH_SCORE: ScorecardEntry = {
+    repo: 'github.com/kyverno/kyverno',
+    score: 8.4,
+    date: '2026-01-01',
+    checks: [
+      { name: 'Maintained', score: 10, reason: 'active' },
+      { name: 'Fuzzing', score: 10, reason: 'fuzzed' },
+    ],
+  };
+
+  const LOW_SCORE: ScorecardEntry = {
+    repo: 'github.com/kyverno/kyverno',
+    score: 3.2,
+    date: '2026-01-01',
+    checks: [
+      { name: 'Fuzzing', score: 0, reason: 'no fuzzing detected' },
+      { name: 'Security-Policy', score: 2, reason: 'no policy found' },
+      { name: 'Maintained', score: 10, reason: 'active' },
+    ],
+  };
+
+  it('falls back to a plain scorecard link when no entry is provided', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('scorecard.dev');
+    expect(html).not.toContain('plb2-scorecard-badge');
+  });
+
+  it('renders the numeric score when a scorecard entry is provided', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, HIGH_SCORE);
+    expect(html).toContain('plb2-scorecard-badge');
+    expect(html).toContain('8.4');
+    expect(html).toContain('/10');
+  });
+
+  it('uses a green color for high scores (>= 7)', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, HIGH_SCORE);
+    expect(html).toContain('#22863a');
+  });
+
+  it('uses a red color for low scores (< 4)', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, LOW_SCORE);
+    expect(html).toContain('#cb2431');
+  });
+
+  it('surfaces the lowest-scoring failing checks', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, LOW_SCORE);
+    expect(html).toContain('plb2-scorecard-check');
+    expect(html).toContain('Fuzzing: 0/10');
+    expect(html).toContain('Security-Policy: 2/10');
+    // Maintained scored 10, above the "failing" threshold — should not show.
+    expect(html).not.toContain('Maintained: 10/10');
+  });
+
+  it('does not render check chips when there are no low-scoring checks', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, HIGH_SCORE);
+    expect(html).not.toContain('plb2-scorecard-check');
+  });
+
+  it('does not render a scorecard badge when repoUrl is absent', () => {
+    const p: SafeProject = { ...BASE_PROJECT, repoUrl: undefined };
+    const html = renderProjectLightboxContent(p, [], NOW, HIGH_SCORE);
+    expect(html).not.toContain('plb2-scorecard-badge');
   });
 });


### PR DESCRIPTION
Addresses part of #29 ("Add more project stats to their hero cards").

## What this PR does

The `go/cmd/enrich` pipeline already fetches a real OpenSSF Scorecard score (0-10, plus per-check breakdown) for every project with a GitHub repo, and writes it to `src/data/projects/openssf-scores.json`. However, that data was never copied into `public/` and was never read by the frontend — the project lightbox only ever rendered a static link to `scorecard.dev`, with no actual score visible on the card.

This PR wires that already-collected data through to the UI:

- `Justfile`: copy `openssf-scores.json` to `public/data/projects/` as part of `copy-data-to-public`, so it ships with the built site like the other data files.
- `project-lightbox.ts`: add `ScorecardEntry`/`ScorecardMap` types mirroring the Go enrich output; lazily fetch `openssf-scores.json` in `openProjectLightbox()` alongside `projects.json` and `maintainers.json`.
- Security section of the lightbox now renders the numeric Scorecard score as a color-coded badge (green >=7, orange >=4, red <4) linking to the full scorecard.dev report, plus small chips listing the project's lowest-scoring individual checks (e.g. `Fuzzing: 0/10`) so it's clear *why* a project scores the way it does — not just a bare external link.
- Falls back gracefully to the previous plain link when no enrichment entry exists yet for a project (non-GitHub repos, or before `just enrich-projects` has been run).

## Why this slice

#29 is a large epic (DORA breakdown, OpenSSF badges, CLO Monitor, Adopters.md logos + End User Member highlighting, Reference Architecture cross-links, GitHub CI stats, etc). Rather than attempt all of it in one PR, this focuses on a concrete, independently testable piece: the OpenSSF Scorecard data was already being collected by the pipeline but sitting unused — this closes that gap. A DORA-style composite health score, CLO Monitor link, and maintainer minicards already exist in the lightbox from prior work; follow-ups can tackle Adopters.md logos + CNCF End User Member highlighting and Reference Architecture cross-linking as their own scoped PRs.

## Testing

- `npx vitest run` — 705/705 tests pass (33 files), including 8 new tests for scorecard badge rendering, color thresholds, failing-check surfacing, and fallback behavior when no repo URL / scorecard entry is present.
- `npx tsc --noEmit` — clean.
- `npx astro check` — 0 errors (only pre-existing hints unrelated to this change).
- `cd go && go build ./... && go vet ./...` — clean (enrich pipeline itself is unchanged, only its output is now consumed).