### PR TITLE
feat(projects): cross-link Reference Architectures in project lightbox (GH #29)

### DIFF
--- a/src/components/projects/ProjectLightbox.astro
+++ b/src/components/projects/ProjectLightbox.astro
@@ -412,6 +412,79 @@
   margin: 0;
 }
 
+/* ─── Reference Architectures ────────────────────────────────────────────── */
+:global(.plb2-refarchs) {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+:global(.plb2-refarch-cards) {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+:global(.plb2-refarch-card) {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-bg-secondary, #f6f8fa);
+  border: 1px solid var(--color-border-default, #d0d7de);
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.12s, background 0.12s;
+}
+:global(.plb2-refarch-card:hover) {
+  border-color: var(--color-accent-emphasis, #0969da);
+  background: var(--color-bg-tertiary, #eaeef2);
+}
+
+:global(.plb2-refarch-logo) {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+:global(.plb2-refarch-logo-placeholder) {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  background: var(--color-bg-tertiary, #eaeef2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #57606a);
+  flex-shrink: 0;
+}
+
+:global(.plb2-refarch-info) {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  min-width: 0;
+}
+
+:global(.plb2-refarch-title) {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #24292f);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:global(.plb2-refarch-org) {
+  font-size: 0.6875rem;
+  color: var(--color-text-muted, #656d76);
+}
+
 /* ─── End users ──────────────────────────────────────────────────────────── */
 :global(.plb2-endusers-link) {
   font-size: 0.8125rem;

--- a/src/lib/projects/project-lightbox.ts
+++ b/src/lib/projects/project-lightbox.ts
@@ -8,10 +8,16 @@
  *
  * Exports
  * ───────
- *  renderProjectLightboxContent(project, maintainers?, now?)  – pure renderer (testable)
- *  openProjectLightbox(slug, base?)                           – lazy fetch + showModal
- *  closeProjectLightbox()                                     – close dialog
- *  initProjectLightbox()                                      – wire close/backdrop/Escape
+ *  renderProjectLightboxContent(project, maintainers?, now?, architectures?) – pure renderer (testable)
+ *  openProjectLightbox(slug, base?)                                          – lazy fetch + showModal
+ *  closeProjectLightbox()                                                    – close dialog
+ *  initProjectLightbox()                                                     – wire close/backdrop/Escape
+ *
+ * GH #29: Reference Architecture cross-linking — cross-refs the project against
+ * src/data/members/architectures.json (by project name, case-insensitive) so a
+ * project's lightbox shows every CNCF Reference Architecture that uses it, linking
+ * out to architecture.cncf.io. Strengthens the projects ↔ members/architectures
+ * relationship requested in GH #29 ("cross seed projects, people, and organizations").
  */
 
 import type { SafeProject } from './project-renderer';
@@ -29,6 +35,20 @@ export interface Maintainer {
   projectDetails?: Array<{ name: string; maturity?: string }>;
   company?: string;
   location?: string;
+}
+
+/**
+ * Minimal shape consumed from src/data/members/architectures.json.
+ * Mirrors (a subset of) SafeArchitecture from src/lib/members/architecture-renderer.ts —
+ * duplicated here (rather than imported) to keep the projects/members boundary clean.
+ */
+export interface ReferenceArchitecture {
+  slug: string;
+  title: string;
+  orgName: string;
+  orgLogoUrl?: string;
+  archUrl: string;
+  projects?: Array<{ name: string }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -230,6 +250,41 @@ function renderContributorMinicards(p: SafeProject, maintainers: Maintainer[]): 
 </div>`;
 }
 
+/**
+ * Cross-link projects to CNCF Reference Architectures that use them.
+ * Matches by project name (case-insensitive) against each architecture's
+ * `projects[]` list — the same data used to render project ribbons on the
+ * architecture cards/modal in the End Users section.
+ */
+function renderReferenceArchitectures(p: SafeProject, architectures: ReferenceArchitecture[]): string {
+  const projectName = p.name.toLowerCase();
+  const matched = architectures.filter(a =>
+    a.projects?.some(proj => proj.name.toLowerCase() === projectName)
+  );
+
+  if (matched.length === 0) return '';
+
+  const cards = matched.map(a => {
+    const title = escapeHtml(a.title);
+    const org = escapeHtml(a.orgName);
+    const logo = a.orgLogoUrl
+      ? `<img class="plb2-refarch-logo" src="${escapeHtml(a.orgLogoUrl)}" alt="${org} logo" width="28" height="28" loading="lazy" />`
+      : `<div class="plb2-refarch-logo-placeholder">${org.charAt(0)}</div>`;
+    return `<a class="plb2-refarch-card" href="${safeHref(a.archUrl)}" target="_blank" rel="noopener noreferrer">
+  ${logo}
+  <div class="plb2-refarch-info">
+    <span class="plb2-refarch-title">${title}</span>
+    <span class="plb2-refarch-org">${org}</span>
+  </div>
+</a>`;
+  }).join('');
+
+  return `<div class="plb2-refarchs">
+  <div class="plb2-section-label">Used in Reference Architectures (${matched.length})</div>
+  <div class="plb2-refarch-cards">${cards}</div>
+</div>`;
+}
+
 function renderEndUsers(p: SafeProject): string {
   const slug = escapeHtml(p.cloMonitorName || p.slug || '');
   const endUsersHref = `https://www.cncf.io/enduser/`;
@@ -284,6 +339,7 @@ export function renderProjectLightboxContent(
   project: SafeProject,
   maintainers: Maintainer[] = [],
   now = new Date(),
+  architectures: ReferenceArchitecture[] = [],
 ): string {
   return `<div class="plb2-content" data-slug="${escapeHtml(project.slug)}">
   ${renderHeader(project)}
@@ -291,6 +347,7 @@ export function renderProjectLightboxContent(
   ${renderStatsRow(project)}
   ${renderSecurityLinks(project)}
   ${renderContributorMinicards(project, maintainers)}
+  ${renderReferenceArchitectures(project, architectures)}
   ${renderEndUsers(project)}
   ${renderTopics(project)}
   ${renderExternalLinks(project)}
@@ -304,6 +361,7 @@ export function renderProjectLightboxContent(
 
 let _projectsCache: SafeProject[] | null = null;
 let _maintainersCache: Maintainer[] | null = null;
+let _architecturesCache: ReferenceArchitecture[] | null = null;
 
 async function fetchProjects(base: string): Promise<SafeProject[]> {
   if (_projectsCache) return _projectsCache;
@@ -320,6 +378,18 @@ async function fetchMaintainers(base: string): Promise<Maintainer[]> {
     if (!res.ok) return [];
     _maintainersCache = (await res.json()) as Maintainer[];
     return _maintainersCache;
+  } catch {
+    return [];
+  }
+}
+
+async function fetchArchitectures(base: string): Promise<ReferenceArchitecture[]> {
+  if (_architecturesCache) return _architecturesCache;
+  try {
+    const res = await fetch(`${base}/data/members/architectures.json`);
+    if (!res.ok) return [];
+    _architecturesCache = (await res.json()) as ReferenceArchitecture[];
+    return _architecturesCache;
   } catch {
     return [];
   }
@@ -357,9 +427,10 @@ export async function openProjectLightbox(slug: string, base = ''): Promise<void
   dialog.showModal();
 
   try {
-    const [projects, maintainers] = await Promise.all([
+    const [projects, maintainers, architectures] = await Promise.all([
       fetchProjects(base),
       fetchMaintainers(base),
+      fetchArchitectures(base),
     ]);
 
     const project = projects.find(p => p.slug === slug);
@@ -368,7 +439,7 @@ export async function openProjectLightbox(slug: string, base = ''): Promise<void
       return;
     }
 
-    content.innerHTML = renderProjectLightboxContent(project, maintainers);
+    content.innerHTML = renderProjectLightboxContent(project, maintainers, new Date(), architectures);
   } catch (err) {
     content.innerHTML = `<p class="plb2-error">Failed to load project data. Please try again.</p>`;
     console.error('[project-lightbox] fetch error:', err);

--- a/tests/unit/projects/project-lightbox.test.ts
+++ b/tests/unit/projects/project-lightbox.test.ts
@@ -18,6 +18,7 @@ import {
   formatNumber,
   formatDate,
   type Maintainer,
+  type ReferenceArchitecture,
 } from '../../../src/lib/projects/project-lightbox';
 import type { SafeProject } from '../../../src/lib/projects/project-renderer';
 
@@ -354,6 +355,99 @@ describe('renderProjectLightboxContent — contributor minicards', () => {
     const p: SafeProject = { ...BASE_PROJECT, logoUrl: '' };
     const html = renderProjectLightboxContent(p, [], NOW);
     expect(html).toContain('plb2-logo-placeholder');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reference Architecture cross-linking (GH #29)
+// ---------------------------------------------------------------------------
+
+const ARCH_KYVERNO: ReferenceArchitecture = {
+  slug: 'swisscom-kubernetes-service',
+  title: 'A modern and sovereign Private Cloud «Kubernetes Service»',
+  orgName: 'Swisscom',
+  orgLogoUrl: 'https://raw.githubusercontent.com/cncf/architecture/main/swisscom-logo.svg',
+  archUrl: 'https://architecture.cncf.io/architectures/swisscom-kubernetes-service/',
+  projects: [{ name: 'Kubernetes' }, { name: 'Kyverno' }, { name: 'Helm' }],
+};
+
+const ARCH_OTHER: ReferenceArchitecture = {
+  slug: 'zeiss',
+  title: 'ZEISS Vision Care - Order Fulfillment',
+  orgName: 'ZEISS',
+  archUrl: 'https://architecture.cncf.io/architectures/zeiss/',
+  projects: [{ name: 'Kubernetes' }, { name: 'Dapr' }],
+};
+
+describe('renderProjectLightboxContent — reference architecture cross-links', () => {
+  it('shows matching reference architecture card', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, [ARCH_KYVERNO]);
+    expect(html).toContain('plb2-refarchs');
+    expect(html).toContain('Swisscom');
+    expect(html).toContain('architecture.cncf.io/architectures/swisscom-kubernetes-service/');
+  });
+
+  it('does not show architectures that do not use this project', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, [ARCH_OTHER]);
+    expect(html).not.toContain('plb2-refarchs');
+    expect(html).not.toContain('ZEISS');
+  });
+
+  it('renders no section when architectures array is empty', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, []);
+    expect(html).not.toContain('plb2-refarchs');
+  });
+
+  it('renders no section when architectures param is omitted', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).not.toContain('plb2-refarchs');
+  });
+
+  it('matches project name case-insensitively', () => {
+    const arch: ReferenceArchitecture = {
+      ...ARCH_KYVERNO,
+      projects: [{ name: 'KYVERNO' }],
+    };
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, [arch]);
+    expect(html).toContain('plb2-refarchs');
+  });
+
+  it('shows count and multiple cards when several architectures match', () => {
+    const arch2: ReferenceArchitecture = {
+      slug: 'adobe',
+      title: "Scaling Adobe's Service Delivery Foundation",
+      orgName: 'Adobe',
+      archUrl: 'https://architecture.cncf.io/architectures/adobe/',
+      projects: [{ name: 'Kyverno' }],
+    };
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, [ARCH_KYVERNO, arch2]);
+    expect(html).toContain('Reference Architectures (2)');
+    expect(html).toContain('Swisscom');
+    expect(html).toContain('Adobe');
+  });
+
+  it('renders logo placeholder when orgLogoUrl is absent', () => {
+    const arch: ReferenceArchitecture = { ...ARCH_KYVERNO, orgLogoUrl: undefined };
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, [arch]);
+    expect(html).toContain('plb2-refarch-logo-placeholder');
+    expect(html).toContain('>S<'); // first letter of "Swisscom"
+  });
+
+  it('escapes XSS in architecture title and org name', () => {
+    const arch: ReferenceArchitecture = {
+      ...ARCH_KYVERNO,
+      title: '<script>alert(1)</script>',
+      orgName: '<img onerror=alert(1)>',
+    };
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, [arch]);
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<img onerror');
+  });
+
+  it('sanitizes unsafe archUrl protocol', () => {
+    const arch: ReferenceArchitecture = { ...ARCH_KYVERNO, archUrl: 'javascript:alert(1)' };
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW, [arch]);
+    expect(html).toContain('href="#"');
   });
 });
 


### PR DESCRIPTION
## Summary

Partial progress on the GH #29 epic ("Add more project stats to their hero cards"). Adds a **"Used in Reference Architectures"** section to the project detail lightbox (`ProjectLightbox.astro` / `project-lightbox.ts`), cross-referencing `src/data/members/architectures.json` by project name (case-insensitive) against the projects each CNCF Reference Architecture reports using. Cards link out to `architecture.cncf.io` and show the submitting organization's name/logo — directly addressing this line from the issue:

> When a project is used in a Reference Architecture ensure the reference architecture is also linked prominently, we want to cross seed projects, people, and organizations.

## Context — what's already done vs. what this PR adds

Most of issue #29's scope is **already implemented** via prior PRs (#95, #100):
- ✅ Project hero lightbox exists (`ProjectLightbox.astro`), triggered from project card clicks
- ✅ DORA-style health score + breakdown (activity/velocity/community/security)
- ✅ OpenSSF Scorecard + CLO Monitor links
- ✅ Contributor minicards cross-referenced from `maintainers.json` (People section)
- ✅ Topics, license, language, stars/forks/contributors stats, external links (GitHub/website/devstats/blog/twitter/slack/LFX Insights)

**This PR adds the one remaining piece for which data was already available in the repo:** Reference Architecture cross-links, using the `projects[]` array already present in `architectures.json` (populated by the Go sync pipeline from `architecture.cncf.io` markdown).

## Remaining epic scope (follow-up needed)

The issue also asks for **Adopters.md organization logos + CNCF End User Member highlighting**. That requires a new data-pipeline capability (fetching/parsing `Adopters.md` from each project's GitHub repo, resolving org names against the CNCF End User Member list) in `stats-go` — a meaningfully larger, separate effort that I'm flagging as follow-up work rather than bundling into this PR. I've left a comment on #29 with this breakdown.

## Changes

- `src/lib/projects/project-lightbox.ts`:
  - New `ReferenceArchitecture` type (mirrors the subset of `SafeArchitecture` needed here).
  - New `renderReferenceArchitectures()` pure renderer — matches by project name, escapes all text, sanitizes `archUrl` via existing `safeHref()`.
  - New `fetchArchitectures()` — lazy-cached fetch of `architectures.json`, same pattern as `fetchMaintainers()`.
  - Wired the new section into `renderProjectLightboxContent()` (new optional 4th param, defaults to `[]` — fully backward compatible) and `openProjectLightbox()`.
- `src/components/projects/ProjectLightbox.astro`: new `.plb2-refarch-*` CSS, namespaced consistently with existing `plb2-*` rules, dark-mode and responsive safe.
- `tests/unit/projects/project-lightbox.test.ts`: 9 new tests — match/no-match, case-insensitive matching, multi-architecture counts, XSS escaping in title/org name, unsafe `archUrl` protocol sanitization.

## Testing

- `npx vitest run` — **707/707 tests pass** (including the 9 new tests + all pre-existing suites).
- `npx astro check` — **0 errors** (pre-existing hints/warnings unrelated to this change).
- `npm run build` — succeeds, all 3 routes (`/`, `/members/`, `/people/`) generate.

Closes part of #29 (Reference Architecture cross-linking). Adopters.md/End User Member highlighting and additional CI-derived stats remain open follow-up work, tracked via a comment on #29.