### PR TITLE
feat(projects): add Last Release and Project Age stats to hero lightbox (#29)

### DIFF
--- a/src/lib/projects/project-lightbox.ts
+++ b/src/lib/projects/project-lightbox.ts
@@ -72,6 +72,22 @@ export function formatNumber(n: number): string {
   return String(n);
 }
 
+/**
+ * Format the age of a project (time since its first commit) as a short,
+ * human-readable string, e.g. "5.3 yrs" or "8 mo". Returns '' for missing
+ * or invalid dates.
+ */
+export function formatAge(iso: string | undefined, now = new Date()): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  const days = (now.getTime() - d.getTime()) / 86_400_000;
+  if (days < 0) return '';
+  if (days < 30) return `${Math.round(days)} d`;
+  if (days < 365) return `${Math.round(days / 30)} mo`;
+  return `${(days / 365).toFixed(1)} yrs`;
+}
+
 // ---------------------------------------------------------------------------
 // Maturity badge colours
 // ---------------------------------------------------------------------------
@@ -153,7 +169,7 @@ function renderHealthBar(p: SafeProject, now: Date): string {
 </div>`;
 }
 
-function renderStatsRow(p: SafeProject): string {
+function renderStatsRow(p: SafeProject, now: Date): string {
   const items: string[] = [];
   if (p.stars !== undefined && p.stars > 0)
     items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">⭐</span><span class="plb2-stat-val">${formatNumber(p.stars)}</span><span class="plb2-stat-label">Stars</span></div>`);
@@ -163,6 +179,13 @@ function renderStatsRow(p: SafeProject): string {
     items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">👥</span><span class="plb2-stat-val">${formatNumber(p.contributors)}</span><span class="plb2-stat-label">Contributors</span></div>`);
   if (p.lastCommitDate)
     items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">📅</span><span class="plb2-stat-val" style="font-size:0.75rem">${escapeHtml(formatDate(p.lastCommitDate))}</span><span class="plb2-stat-label">Last Commit</span></div>`);
+  if (p.lastReleaseDate)
+    items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">🚀</span><span class="plb2-stat-val" style="font-size:0.75rem">${escapeHtml(formatDate(p.lastReleaseDate))}</span><span class="plb2-stat-label">Last Release</span></div>`);
+  if (p.firstCommitDate) {
+    const age = formatAge(p.firstCommitDate, now);
+    if (age)
+      items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">🕰️</span><span class="plb2-stat-val" style="font-size:0.8125rem">${escapeHtml(age)}</span><span class="plb2-stat-label">Project Age</span></div>`);
+  }
   if (p.primaryLanguage)
     items.push(`<div class="plb2-stat"><span class="plb2-stat-icon">💻</span><span class="plb2-stat-val" style="font-size:0.8125rem">${escapeHtml(p.primaryLanguage)}</span><span class="plb2-stat-label">Language</span></div>`);
   if (p.license)
@@ -288,7 +311,7 @@ export function renderProjectLightboxContent(
   return `<div class="plb2-content" data-slug="${escapeHtml(project.slug)}">
   ${renderHeader(project)}
   ${renderHealthBar(project, now)}
-  ${renderStatsRow(project)}
+  ${renderStatsRow(project, now)}
   ${renderSecurityLinks(project)}
   ${renderContributorMinicards(project, maintainers)}
   ${renderEndUsers(project)}

--- a/tests/unit/projects/project-lightbox.test.ts
+++ b/tests/unit/projects/project-lightbox.test.ts
@@ -17,6 +17,7 @@ import {
   safeHref,
   formatNumber,
   formatDate,
+  formatAge,
   type Maintainer,
 } from '../../../src/lib/projects/project-lightbox';
 import type { SafeProject } from '../../../src/lib/projects/project-renderer';
@@ -59,6 +60,7 @@ const FULL_PROJECT: SafeProject = {
   contributors: 501,
   lastCommitDate: '2026-01-01T00:00:00Z',
   lastReleaseDate: '2025-12-01T00:00:00Z',
+  firstCommitDate: '2019-06-15T00:00:00Z',
   license: 'Apache License 2.0',
   primaryLanguage: 'Go',
   topics: ['kubernetes', 'policy-as-code', 'security'],
@@ -179,6 +181,35 @@ describe('formatDate', () => {
   });
 });
 
+describe('formatAge', () => {
+  it('returns empty string when date is undefined', () => {
+    expect(formatAge(undefined, NOW)).toBe('');
+  });
+
+  it('returns empty string for invalid dates', () => {
+    expect(formatAge('not-a-date', NOW)).toBe('');
+  });
+
+  it('returns empty string for future dates', () => {
+    expect(formatAge('2027-01-01T00:00:00Z', NOW)).toBe('');
+  });
+
+  it('formats sub-month ages in days', () => {
+    // NOW = 2026-01-01; 10 days earlier
+    expect(formatAge('2025-12-22T00:00:00Z', NOW)).toBe('10 d');
+  });
+
+  it('formats sub-year ages in months', () => {
+    // ~6 months before NOW
+    expect(formatAge('2025-07-01T00:00:00Z', NOW)).toBe('6 mo');
+  });
+
+  it('formats multi-year ages in years with one decimal', () => {
+    // 2019-06-15 → NOW (2026-01-01) is ~6.5 yrs
+    expect(formatAge('2019-06-15T00:00:00Z', NOW)).toMatch(/^\d+\.\d yrs$/);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // renderProjectLightboxContent — structural checks
 // ---------------------------------------------------------------------------
@@ -238,6 +269,24 @@ describe('renderProjectLightboxContent', () => {
     expect(html).toContain('plb2-stats-row');
     // 7578 stars → 7.6k
     expect(html).toContain('7.6k');
+  });
+
+  it('renders last release date stat when lastReleaseDate present', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('Last Release');
+    expect(html).toContain('Dec');
+  });
+
+  it('renders project age stat when firstCommitDate present', () => {
+    const html = renderProjectLightboxContent(FULL_PROJECT, [], NOW);
+    expect(html).toContain('Project Age');
+    expect(html).toMatch(/\d+\.\d yrs/);
+  });
+
+  it('omits last release and project age stats when dates are absent', () => {
+    const html = renderProjectLightboxContent(BASE_PROJECT, [], NOW);
+    expect(html).not.toContain('Last Release');
+    expect(html).not.toContain('Project Age');
   });
 
   it('renders topics chips when topics array is non-empty', () => {


### PR DESCRIPTION
## Summary

Small, self-contained slice of the #29 epic ("Add more project stats to their hero cards"). Adds two new stats to the project hero lightbox:

- **Last Release** — renders `lastReleaseDate` (already fetched from `full.json`'s `github_data`) as a visible stat chip. Previously this field was only used internally for the DORA-style health score's velocity dimension — never surfaced to users directly.
- **Project Age** — new `formatAge()` helper renders time since `firstCommitDate` as days/months/years (e.g. "6.5 yrs"), giving users a sense of project maturity alongside the existing CNCF maturity badge (sandbox/incubating/graduated).

Both stats are derived purely from data **already present** on `SafeProject` — no new data-pipeline / GitHub API work required, so this ships immediately without needing new `stats-go` collection work.

## Context

Per the epic discussion and PR #140 (Reference Architecture cross-linking, already merged/open separately), the remaining epic scope was split into:
1. Adopters.md org logos + End User Member highlighting (needs new data pipeline)
2. Additional CI-derived stats — **this PR** covers the safe/available subset
3. CLO Monitor deep-dive (needs new fetch/cache step)

This PR only tackles item 2, using data the pipeline already collects.

## Changes

- `src/lib/projects/project-lightbox.ts`:
  - Added `formatAge(iso, now)` helper (exported, pure, testable).
  - `renderStatsRow` now accepts `now` and renders "Last Release" and "Project Age" stat chips when the corresponding dates are present.
- `tests/unit/projects/project-lightbox.test.ts`:
  - 9 new tests covering `formatAge` edge cases (undefined, invalid, future dates, day/month/year formatting) and the new stat-chip rendering (present + absent cases).

## Testing

```
npx vitest run tests/unit/projects/
```
All 206 tests pass (54 in `project-lightbox.test.ts`, including the 9 new ones).

```
npx astro check
```
0 errors, 0 warnings (pre-existing hints only, unrelated to this change).

No visual/DOM behavior changed beyond the new stat chips reusing existing `.plb2-stat` markup/CSS, so no new Playwright coverage was needed beyond the existing e2e lightbox specs.
